### PR TITLE
patch api.py for decoupled remote use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN if [ "$IMAGE_TYPE" != "elite" ]; then \
         python -m nltk.downloader averaged_perceptron_tagger cmudict; \
     fi
 
+RUN python -m nltk.downloader averaged_perceptron_tagger_eng
 
 # Copy the rest of the application
 COPY . /workspace

--- a/api.py
+++ b/api.py
@@ -669,6 +669,9 @@ def handle_control(command):
 
 
 def handle_change(path, text, language):
+    with open(text) as inp:
+        text = inp.read().strip()
+
     if is_empty(path, text, language):
         return JSONResponse({"code": 400, "message": '缺少任意一项以下参数: "path", "text", "language"'}, status_code=400)
 
@@ -689,6 +692,10 @@ def handle_change(path, text, language):
 
 
 def handle(refer_wav_path, prompt_text, prompt_language, text, text_language, cut_punc, top_k, top_p, temperature, speed, inp_refs):
+    if prompt_text:
+        with open(prompt_text) as inp:
+            prompt_text = inp.read().strip()
+
     if (
             refer_wav_path == "" or refer_wav_path is None
             or prompt_text == "" or prompt_text is None


### PR DESCRIPTION
Changes:
- Have api.py acceptx a file path for prompt_text instead of the actual text. This makes it so the caller doesn't need to know specifics about what reference files are available, which makes it easier to decouple the caller from the api server.
- Install averaged_perceptron_tagger_eng in Dockerfile